### PR TITLE
Expand gitignore for Vim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,15 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+### Vim ###
+# swap
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+# session
+Session.vim
+# temporary
+.netrwhist
+*~
+# auto-generated tag files
+tags


### PR DESCRIPTION
This expands the content of the gitignore file to include temporary files produced Vim (the editor I use). In addition to this, the section which concerns Java temporary file has been annotated as such.
