### PR TITLE
Refactored to allow for multiple players

### DIFF
--- a/game/core/src/org/teamfarce/mirch/GUIController.java
+++ b/game/core/src/org/teamfarce/mirch/GUIController.java
@@ -87,7 +87,7 @@ public class GUIController {
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
         // Get latest game state
-        GameState newState = game.gameSnapshot.getState();
+        GameState newState = game.getCurrentGameSnapshot().getState();
 
         // Check if screen needs changing
         if (currentState != newState) {

--- a/game/core/src/org/teamfarce/mirch/GameSnapshot.java
+++ b/game/core/src/org/teamfarce/mirch/GameSnapshot.java
@@ -2,10 +2,12 @@ package org.teamfarce.mirch;
 
 import com.badlogic.gdx.Gdx;
 import org.teamfarce.mirch.entities.Clue;
+import org.teamfarce.mirch.entities.Player;
 import org.teamfarce.mirch.entities.Suspect;
 import org.teamfarce.mirch.map.Map;
 import org.teamfarce.mirch.map.Room;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
@@ -27,7 +29,6 @@ public class GameSnapshot {
     public Clue meansClue;
     MIRCH game;
     List<Clue> clues;
-    List<Room> rooms;
 
     int currentPersonality;
     private List<Suspect> suspects;
@@ -35,6 +36,10 @@ public class GameSnapshot {
     private Suspect interviewSuspect = null;
 
     public final ScoreTracker scoreTracker = new ScoreTracker();
+    public Player player;
+    public ArrayList<Suspect> characters;
+    public List<Room> rooms;
+    public ArrayList<Room> mirchRooms;
 
     /**
      * Initialises function.
@@ -62,7 +67,7 @@ public class GameSnapshot {
         String weapon = meansClue.getName();
 
         // Get the murder room name and the murder weapon
-        for (Room r: game.gameSnapshot.map.getRooms()) {
+        for (Room r: game.getCurrentGameSnapshot().map.getRooms()) {
             if (r.isMurderRoom()) {
                 room = r.getName();
             }
@@ -95,7 +100,7 @@ public class GameSnapshot {
                 }
             );
 
-        game.gameSnapshot.setState(GameState.narrator);
+        game.getCurrentGameSnapshot().setState(GameState.narrator);
     }
 
     /**

--- a/game/core/src/org/teamfarce/mirch/Journal.java
+++ b/game/core/src/org/teamfarce/mirch/Journal.java
@@ -41,9 +41,9 @@ public class Journal {
     public void addClue(Clue clue) {
         this.foundClues.add(clue);
 
-        game.gameSnapshot.setAllUnlocked();
+        game.getCurrentGameSnapshot().setAllUnlocked();
 
-        this.game.gameSnapshot.scoreTracker.addClue();
+        this.game.getCurrentGameSnapshot().scoreTracker.addClue();
 
         if (clue.isMotiveClue())
             motivesFound++;
@@ -72,12 +72,12 @@ public class Journal {
                 new Runnable() {
                     @Override
                     public void run() {
-                        game.gameSnapshot.setState(GameState.map);
+                        game.getCurrentGameSnapshot().setState(GameState.map);
                     }
                 }
             );
 
-        game.gameSnapshot.setState(GameState.narrator);
+        game.getCurrentGameSnapshot().setState(GameState.narrator);
     }
 
     /**

--- a/game/core/src/org/teamfarce/mirch/MIRCH.java
+++ b/game/core/src/org/teamfarce/mirch/MIRCH.java
@@ -37,16 +37,18 @@ public class MIRCH extends Game {
             database = new ScenarioBuilderDatabase("db.db");
 
             try {
-                for (int i = 0; i < PLAYERNO; i++){
+                for (int i = 0; i < PLAYERNO; i++) {
 
-                    this.gameSnapshots.add(ScenarioBuilder.generateGame(this, database, new Random()));
+                    this.gameSnapshots
+                        .add(ScenarioBuilder.generateGame(this, database, new Random()));
 
-                    this.currentSnapshot = i; //move to the game snapshot we just added
+                    this.currentSnapshot = i; // move to the game snapshot we just added
 
                     // generate RenderItems from each room
                     getCurrentGameSnapshot().mirchRooms = new ArrayList<>();
                     for (Room room: getCurrentGameSnapshot().getRooms()) {
-                        getCurrentGameSnapshot().mirchRooms.add(room); // create a new renderItem for the room
+                        getCurrentGameSnapshot().mirchRooms.add(room); // create a new renderItem
+                                                                       // for the room
                     }
 
                     // generate RenderItems for each prop
@@ -57,7 +59,8 @@ public class MIRCH extends Game {
                         getCurrentGameSnapshot().characters.add(suspect);
                     }
 
-                    getCurrentGameSnapshot().map.placeNPCsInRooms(getCurrentGameSnapshot().characters);
+                    getCurrentGameSnapshot().map
+                        .placeNPCsInRooms(getCurrentGameSnapshot().characters);
 
                     // initialise the player sprite
                     Dialogue playerDialogue = null;
@@ -78,7 +81,8 @@ public class MIRCH extends Game {
                         );
 
                     getCurrentGameSnapshot().player.setTileCoordinates(7, 10);
-                    getCurrentGameSnapshot().player.setRoom(getCurrentGameSnapshot().mirchRooms.get(0));
+                    getCurrentGameSnapshot().player
+                        .setRoom(getCurrentGameSnapshot().mirchRooms.get(0));
                 }
             } catch (ScenarioBuilderException e) {
                 // TODO Auto-generated catch block
@@ -112,23 +116,21 @@ public class MIRCH extends Game {
 
     /**
      * Finds and returns the current game snapshot.
-     * @return
-     * @author TeamFARCE - jacobwunwin
+     *
+     * @return The game snapshot object.
      */
     public GameSnapshot getCurrentGameSnapshot() {
         return this.gameSnapshots.get(this.currentSnapshot);
     }
 
-    /*
-     * Moves the game to the next game snapshot
-     * @author TeamFARCE - jacobwunwin
+    /**
+     * Moves the game to the next game snapshot.
      */
-    public void nextGameSnapshot(){
-        this.currentSnapshot += 1; //increment the current snapshot pointer
-        //move the snapshot pointer back to 0 if its reached the end of the list
-        if (this.currentSnapshot >= this.gameSnapshots.size()){
+    public void nextGameSnapshot() {
+        this.currentSnapshot += 1; // increment the current snapshot pointer
+        // move the snapshot pointer back to 0 if its reached the end of the list
+        if (this.currentSnapshot >= this.gameSnapshots.size()) {
             this.currentSnapshot = 0;
         }
     }
-
 }

--- a/game/core/src/org/teamfarce/mirch/MIRCH.java
+++ b/game/core/src/org/teamfarce/mirch/MIRCH.java
@@ -133,4 +133,14 @@ public class MIRCH extends Game {
             this.currentSnapshot = 0;
         }
     }
+
+    /**
+     * Adds and sets the current snapshot to the one given.
+     *
+     * @param snapshot The snapshot to use.
+     */
+    public void setGameSnapshot(GameSnapshot snapshot) {
+        this.gameSnapshots.add(snapshot);
+        this.currentSnapshot = this.gameSnapshots.size() - 1;
+    }
 }

--- a/game/core/src/org/teamfarce/mirch/OrthogonalTiledMapRendererWithPeople.java
+++ b/game/core/src/org/teamfarce/mirch/OrthogonalTiledMapRendererWithPeople.java
@@ -82,7 +82,10 @@ public class OrthogonalTiledMapRendererWithPeople extends OrthogonalTiledMapRend
         for (int currentLayer = 0; currentLayer < amountOfLayers; currentLayer++) {
             MapLayer layer = map.getLayers().get(currentLayer);
 
-            if (layer.getName().equals("Blood") && !this.mirchRef.getCurrentGameSnapshot().player.getRoom().isMurderRoom()) {
+            if (
+                layer.getName().equals("Blood")
+                    && !this.mirchRef.getCurrentGameSnapshot().player.getRoom().isMurderRoom()
+            ) {
                 // Don't draw the layer as its not the murder room
             } else {
                 renderTileLayer((TiledMapTileLayer) layer);

--- a/game/core/src/org/teamfarce/mirch/OrthogonalTiledMapRendererWithPeople.java
+++ b/game/core/src/org/teamfarce/mirch/OrthogonalTiledMapRendererWithPeople.java
@@ -82,7 +82,7 @@ public class OrthogonalTiledMapRendererWithPeople extends OrthogonalTiledMapRend
         for (int currentLayer = 0; currentLayer < amountOfLayers; currentLayer++) {
             MapLayer layer = map.getLayers().get(currentLayer);
 
-            if (layer.getName().equals("Blood") && !this.mirchRef.player.getRoom().isMurderRoom()) {
+            if (layer.getName().equals("Blood") && !this.mirchRef.getCurrentGameSnapshot().player.getRoom().isMurderRoom()) {
                 // Don't draw the layer as its not the murder room
             } else {
                 renderTileLayer((TiledMapTileLayer) layer);

--- a/game/core/src/org/teamfarce/mirch/ScoreCalculator.java
+++ b/game/core/src/org/teamfarce/mirch/ScoreCalculator.java
@@ -1,12 +1,15 @@
 package org.teamfarce.mirch;
 
 /**
- * A score calculator function which takes the given parameters and provides back a simple
- * integer score.
+ * A score calculator function which takes the given parameters and provides back a simple integer
+ * score.
  */
 public class ScoreCalculator implements ScoreTracker.ScoreCalculator {
     public int calculateScore(
-        int timeTaken, int incorrectAccusations, int askedQuestions, int cluesFound
+        int timeTaken,
+        int incorrectAccusations,
+        int askedQuestions,
+        int cluesFound
     ) {
         // Decrease the score by 1 every 5 seconds.
         final int timeScore = -(timeTaken / 300);

--- a/game/core/src/org/teamfarce/mirch/ScoreTracker.java
+++ b/game/core/src/org/teamfarce/mirch/ScoreTracker.java
@@ -31,7 +31,10 @@ public class ScoreTracker {
          * @return The score.
          */
         public int calculateScore(
-            int timeTaken, int incorrectAccusations, int askedQuestions, int cluesFound
+            int timeTaken,
+            int incorrectAccusations,
+            int askedQuestions,
+            int cluesFound
         );
     }
 

--- a/game/core/src/org/teamfarce/mirch/entities/Player.java
+++ b/game/core/src/org/teamfarce/mirch/entities/Player.java
@@ -272,14 +272,14 @@ public class Player extends AbstractPerson {
                 .setDirection(getTileCoordinates().dirBetween(talkToOnEnd.getTileCoordinates()));
             setDirection(talkToOnEnd.direction.getOpposite());
 
-            game.gameSnapshot.setState(GameState.interviewStart);
-            game.gameSnapshot.setSuspectForInterview(talkToOnEnd);
+            game.getCurrentGameSnapshot().setState(GameState.interviewStart);
+            game.getCurrentGameSnapshot().setSuspectForInterview(talkToOnEnd);
         }
 
         if (toMoveTo.isEmpty() && findOnEnd != null) {
             setDirection(findOnEnd.getTileCoordinates().dirBetween(getTileCoordinates()));
             MapScreen.grabScreenshot = true;
-            game.gameSnapshot.setState(GameState.findClue);
+            game.getCurrentGameSnapshot().setState(GameState.findClue);
         }
 
         if (toMoveTo.isEmpty() && transitionOnEnd) {

--- a/game/core/src/org/teamfarce/mirch/entities/Suspect.java
+++ b/game/core/src/org/teamfarce/mirch/entities/Suspect.java
@@ -61,7 +61,7 @@ public class Suspect extends AbstractPerson {
         this.beenAccused = true;
         // clear the dialogue tree here
         if (this.killer == false || hasEvidence == false) {
-            this.game.gameSnapshot.scoreTracker.addIncorrectAccusation();
+            this.game.getCurrentGameSnapshot().scoreTracker.addIncorrectAccusation();
         }
         return (this.killer) && (hasEvidence);
     }

--- a/game/core/src/org/teamfarce/mirch/map/Map.java
+++ b/game/core/src/org/teamfarce/mirch/map/Map.java
@@ -30,9 +30,8 @@ public class Map {
         Room rch037 = new Room(1, "rch037.tmx", "RCH/037 Lecture Theatre", this.game);
         Room portersOffice = new Room(2, "portersoffice.tmx", "Porters Office", this.game);
         Room kitchen = new Room(3, "kitchen.tmx", "Kitchen", this.game);
-        Room islandOfInteraction = new Room(
-            4, "islandofinteraction.tmx", "Island of Interaction", this.game
-        );
+        Room islandOfInteraction =
+            new Room(4, "islandofinteraction.tmx", "Island of Interaction", this.game);
         Room toilet = new Room(5, "toilet.tmx", "Toilet", this.game);
         Room computerRoom = new Room(6, "computerroom.tmx", "Computer Room", this.game);
         Room lakeHouse = new Room(7, "lakehouse.tmx", "Lakehouse", this.game);
@@ -51,9 +50,8 @@ public class Map {
                     .setFrom(26, 29)
                     .setTo(islandOfInteraction, 11, 14, Direction.WEST)
             ) // To Island of Interaction
-            .addTransition(
-                new Room.Transition().setFrom(18, 2).setTo(toilet, 1, 1, Direction.EAST)
-            ) // To Toilet
+            .addTransition(new Room.Transition().setFrom(18, 2).setTo(toilet, 1, 1, Direction.EAST)) // To
+                                                                                                     // Toilet
             .addTransition(
                 new Room.Transition().setFrom(2, 8).setTo(computerRoom, 2, 2, Direction.EAST)
             ) // To Computer Room
@@ -125,12 +123,10 @@ public class Map {
             .addTransition(
                 new Room.Transition().setFrom(20, 4).setTo(mainRoom, 4, 5, Direction.NORTH)
             ) // To Main Room
-            .addTransition(
-                new Room.Transition().setFrom(9, 11).setTo(pod, 18, 9, Direction.WEST)
-            ) // To Pod
-            .addTransition(
-                new Room.Transition().setFrom(9, 12).setTo(pod, 18, 10, Direction.WEST)
-            ); // To Pod
+            .addTransition(new Room.Transition().setFrom(9, 11).setTo(pod, 18, 9, Direction.WEST)) // To
+                                                                                                   // Pod
+            .addTransition(new Room.Transition().setFrom(9, 12).setTo(pod, 18, 10, Direction.WEST)); // To
+                                                                                                     // Pod
 
         pod
             .addTransition(
@@ -173,7 +169,7 @@ public class Map {
     public List<Suspect> getNPCs(Room room) {
         List<Suspect> npcsInRoom = new ArrayList<Suspect>();
 
-        for (Suspect s: game.gameSnapshot.getSuspects()) {
+        for (Suspect s: game.getCurrentGameSnapshot().getSuspects()) {
             if (s.getRoom().getID() == room.getID()) {
                 npcsInRoom.add(s);
             }

--- a/game/core/src/org/teamfarce/mirch/map/Room.java
+++ b/game/core/src/org/teamfarce/mirch/map/Room.java
@@ -290,8 +290,8 @@ public class Room {
              * Check to see if the player is standing in the target destination
              */
             if (
-                mirchRef.player.getTileCoordinates().x == x
-                    && mirchRef.player.getTileCoordinates().y == y
+                mirchRef.getCurrentGameSnapshot().player.getTileCoordinates().x == x
+                    && mirchRef.getCurrentGameSnapshot().player.getTileCoordinates().y == y
             ) {
                 return false;
             }
@@ -299,7 +299,7 @@ public class Room {
             /*
              * Check to see if any NPCs are standing in the target destination
              */
-            for (Suspect suspect: mirchRef.characters) {
+            for (Suspect suspect: mirchRef.getCurrentGameSnapshot().characters) {
 
                 if (
                     suspect.getRoom() == this && suspect.getTileCoordinates().x == x

--- a/game/core/src/org/teamfarce/mirch/screens/FindClueScreen.java
+++ b/game/core/src/org/teamfarce/mirch/screens/FindClueScreen.java
@@ -57,10 +57,10 @@ public class FindClueScreen extends AbstractScreen {
      */
     public FindClueScreen(MIRCH game, Skin uiSkin) {
         super(game);
-        this.snapshot = game.gameSnapshot;
+        this.snapshot = game.getCurrentGameSnapshot();
         this.uiSkin = uiSkin;
 
-        statusBar = new StatusBar(game.gameSnapshot, uiSkin);
+        statusBar = new StatusBar(game.getCurrentGameSnapshot(), uiSkin);
     }
 
     /**
@@ -87,7 +87,7 @@ public class FindClueScreen extends AbstractScreen {
         clueBox = new Image(Assets.loadTexture("clues/clueBox.png"));
         clueBox.setSize(Settings.TILE_SIZE * 1.1f, Settings.TILE_SIZE * 1.1f);
 
-        displayingClue = game.player.getClueFound();
+        displayingClue = game.getCurrentGameSnapshot().player.getClueFound();
         clueImage =
             new Image(
                 new TextureRegion(
@@ -163,9 +163,9 @@ public class FindClueScreen extends AbstractScreen {
 
             if (soFarAnim >= ANIM_TIME * 0.5f) {
                 if (continueButton != null) {
-                    game.gameSnapshot.setState(GameState.map);
+                    game.getCurrentGameSnapshot().setState(GameState.map);
 
-                    game.gameSnapshot.journal.addClue(displayingClue);
+                    game.getCurrentGameSnapshot().journal.addClue(displayingClue);
                 } else {
                     addAllToStage();
                 }
@@ -209,8 +209,8 @@ public class FindClueScreen extends AbstractScreen {
                     soFarAnim = 0f;
                     ANIM_TIME = 2f;
 
-                    game.player.getRoom().removeClue(displayingClue);
-                    game.player.clearFound();
+                    game.getCurrentGameSnapshot().player.getRoom().removeClue(displayingClue);
+                    game.getCurrentGameSnapshot().player.clearFound();
                 }
             }
         );

--- a/game/core/src/org/teamfarce/mirch/screens/InterviewScreen.java
+++ b/game/core/src/org/teamfarce/mirch/screens/InterviewScreen.java
@@ -52,7 +52,7 @@ public class InterviewScreen extends AbstractScreen {
     public InterviewScreen(MIRCH game, Skin uiSkin) {
         super(game);
         this.game = game;
-        this.gameSnapshot = game.gameSnapshot;
+        this.gameSnapshot = game.getCurrentGameSnapshot();
         this.uiSkin = uiSkin;
     }
 
@@ -126,7 +126,7 @@ public class InterviewScreen extends AbstractScreen {
                 new InterviewResponseButton("Question the suspect", 0, null, switchStateHandler)
             );
 
-            if (game.gameSnapshot.isMeansProven() && game.gameSnapshot.isMotiveProven()) {
+            if (game.getCurrentGameSnapshot().isMeansProven() && game.getCurrentGameSnapshot().isMotiveProven()) {
                 buttonList.add(
                     new InterviewResponseButton("Accuse the suspect", 1, null, switchStateHandler)
                 );
@@ -148,7 +148,7 @@ public class InterviewScreen extends AbstractScreen {
 
                 // Setup buttons to Question, Accuse and Ignore
 
-                for (Clue c: game.gameSnapshot.journal.getQuestionableClues()) {
+                for (Clue c: game.getCurrentGameSnapshot().journal.getQuestionableClues()) {
                     buttonList.add(new InterviewResponseButton(c.getName(), 0, c, clueHandler));
                 }
             } else {
@@ -176,7 +176,7 @@ public class InterviewScreen extends AbstractScreen {
             if (personality <= 5) {
                 buttonList.add(
                     new InterviewResponseButton(
-                        "Aggressively: " + game.player.dialogue.get(tempClue, "AGGRESSIVE"),
+                        "Aggressively: " + game.getCurrentGameSnapshot().player.dialogue.get(tempClue, "AGGRESSIVE"),
                         0,
                         null,
                         styleHandler
@@ -186,7 +186,7 @@ public class InterviewScreen extends AbstractScreen {
 
             buttonList.add(
                 new InterviewResponseButton(
-                    "Conversational: " + game.player.dialogue.get(tempClue, "CONVERSATIONAL"),
+                    "Conversational: " + game.getCurrentGameSnapshot().player.dialogue.get(tempClue, "CONVERSATIONAL"),
                     1,
                     null,
                     styleHandler
@@ -196,7 +196,7 @@ public class InterviewScreen extends AbstractScreen {
             if (personality >= -5) {
                 buttonList.add(
                     new InterviewResponseButton(
-                        "Politely: " + game.player.dialogue.get(tempClue, "POLITE"),
+                        "Politely: " + game.getCurrentGameSnapshot().player.dialogue.get(tempClue, "POLITE"),
                         2,
                         null,
                         styleHandler
@@ -214,7 +214,7 @@ public class InterviewScreen extends AbstractScreen {
             if (suspectDialogue.length() == 0) {
                 suspectDialogue = suspect.dialogue.get("none");
             } else {
-                this.game.gameSnapshot.scoreTracker.addQuestion();
+                this.game.getCurrentGameSnapshot().scoreTracker.addQuestion();
                 gameSnapshot.journal.addConversation(
                     String.format("%s?: %s ", tempClue.getName(), suspectDialogue),
                     suspect.getName()
@@ -232,7 +232,7 @@ public class InterviewScreen extends AbstractScreen {
                 )
             );
 
-            if (game.gameSnapshot.isMeansProven() && game.gameSnapshot.isMotiveProven()) {
+            if (game.getCurrentGameSnapshot().isMeansProven() && game.getCurrentGameSnapshot().isMotiveProven()) {
                 buttonList.add(
                     new InterviewResponseButton("Accuse the suspect", 1, null, switchStateHandler)
                 );
@@ -337,7 +337,7 @@ public class InterviewScreen extends AbstractScreen {
 
         game.guiController.narratorScreen.setSpeech(
             "Congratulations! You solved it!\n\n" + "All along it was "
-                + game.gameSnapshot.murderer.getName() + " who killed "
+                + game.getCurrentGameSnapshot().murderer.getName() + " who killed "
                 + gameSnapshot.victim.getName() + " with " + gameSnapshot.meansClue.getName()
                 + " in the " + room
                 + "\n\nI would never have been able to work that out!\n\nYou completed the game with a score of "
@@ -401,7 +401,7 @@ public class InterviewScreen extends AbstractScreen {
             suspect.setLocked(true);
             suspect = null;
             gameSnapshot.setSuspectForInterview(null);
-            game.player.clearTalkTo();
+            game.getCurrentGameSnapshot().player.clearTalkTo();
             break;
         case 3: // Game has been won
             winGame();
@@ -411,7 +411,7 @@ public class InterviewScreen extends AbstractScreen {
             suspect.canMove = true;
             suspect = null;
             gameSnapshot.setSuspectForInterview(null);
-            game.player.clearTalkTo();
+            game.getCurrentGameSnapshot().player.clearTalkTo();
             break;
         }
     }

--- a/game/core/src/org/teamfarce/mirch/screens/InterviewScreen.java
+++ b/game/core/src/org/teamfarce/mirch/screens/InterviewScreen.java
@@ -126,7 +126,10 @@ public class InterviewScreen extends AbstractScreen {
                 new InterviewResponseButton("Question the suspect", 0, null, switchStateHandler)
             );
 
-            if (game.getCurrentGameSnapshot().isMeansProven() && game.getCurrentGameSnapshot().isMotiveProven()) {
+            if (
+                game.getCurrentGameSnapshot().isMeansProven()
+                    && game.getCurrentGameSnapshot().isMotiveProven()
+            ) {
                 buttonList.add(
                     new InterviewResponseButton("Accuse the suspect", 1, null, switchStateHandler)
                 );
@@ -176,7 +179,8 @@ public class InterviewScreen extends AbstractScreen {
             if (personality <= 5) {
                 buttonList.add(
                     new InterviewResponseButton(
-                        "Aggressively: " + game.getCurrentGameSnapshot().player.dialogue.get(tempClue, "AGGRESSIVE"),
+                        "Aggressively: " + game.getCurrentGameSnapshot().player.dialogue
+                            .get(tempClue, "AGGRESSIVE"),
                         0,
                         null,
                         styleHandler
@@ -186,7 +190,8 @@ public class InterviewScreen extends AbstractScreen {
 
             buttonList.add(
                 new InterviewResponseButton(
-                    "Conversational: " + game.getCurrentGameSnapshot().player.dialogue.get(tempClue, "CONVERSATIONAL"),
+                    "Conversational: " + game.getCurrentGameSnapshot().player.dialogue
+                        .get(tempClue, "CONVERSATIONAL"),
                     1,
                     null,
                     styleHandler
@@ -196,7 +201,8 @@ public class InterviewScreen extends AbstractScreen {
             if (personality >= -5) {
                 buttonList.add(
                     new InterviewResponseButton(
-                        "Politely: " + game.getCurrentGameSnapshot().player.dialogue.get(tempClue, "POLITE"),
+                        "Politely: "
+                            + game.getCurrentGameSnapshot().player.dialogue.get(tempClue, "POLITE"),
                         2,
                         null,
                         styleHandler
@@ -232,7 +238,10 @@ public class InterviewScreen extends AbstractScreen {
                 )
             );
 
-            if (game.getCurrentGameSnapshot().isMeansProven() && game.getCurrentGameSnapshot().isMotiveProven()) {
+            if (
+                game.getCurrentGameSnapshot().isMeansProven()
+                    && game.getCurrentGameSnapshot().isMotiveProven()
+            ) {
                 buttonList.add(
                     new InterviewResponseButton("Accuse the suspect", 1, null, switchStateHandler)
                 );

--- a/game/core/src/org/teamfarce/mirch/screens/JournalScreen.java
+++ b/game/core/src/org/teamfarce/mirch/screens/JournalScreen.java
@@ -70,10 +70,10 @@ public class JournalScreen extends AbstractScreen {
     public JournalScreen(MIRCH game, Skin uiSkin) {
         super(game);
         this.game = game;
-        this.gameSnapshot = game.gameSnapshot;
+        this.gameSnapshot = game.getCurrentGameSnapshot();
         this.uiSkin = uiSkin;
 
-        statusBar = new StatusBar(game.gameSnapshot, uiSkin);
+        statusBar = new StatusBar(game.getCurrentGameSnapshot(), uiSkin);
 
         // Initialise notepad page here to preserve page contents across screen transitions
         notepadPage = initJournalNotepadPage();
@@ -142,7 +142,7 @@ public class JournalScreen extends AbstractScreen {
         clueContainer.addActor(clueDesc);
         clueContainer.addActor(clueImage);
 
-        if (game.gameSnapshot.journal.getClues().size() == 0) {
+        if (game.getCurrentGameSnapshot().journal.getClues().size() == 0) {
             clueContainer.setVisible(false);
         }
 
@@ -151,12 +151,12 @@ public class JournalScreen extends AbstractScreen {
 
         // Load details page onto right journal page
         Table detailsPage;
-        GameState currentState = game.gameSnapshot.getState();
+        GameState currentState = game.getCurrentGameSnapshot().getState();
         switch (currentState) {
         case journalClues:
             detailsPage = initJournalCluesPage();
 
-            if (game.gameSnapshot.journal.getClues().size() != 0) {
+            if (game.getCurrentGameSnapshot().journal.getClues().size() != 0) {
                 clueContainer.setVisible(true);
             }
 
@@ -225,7 +225,7 @@ public class JournalScreen extends AbstractScreen {
         page.addActor(getJournalPageSubtitle("Click and drag below to scroll", 1));
 
         // Add list of found clues to journal
-        List<Clue> clues = game.gameSnapshot.journal.getClues();
+        List<Clue> clues = game.getCurrentGameSnapshot().journal.getClues();
 
         // Loop through each clue and add to table
         Table content = new Table();
@@ -239,7 +239,7 @@ public class JournalScreen extends AbstractScreen {
                     @Override
                     public void clicked(InputEvent event, float x, float y) {
 
-                        for (Clue c: game.gameSnapshot.journal.getClues()) {
+                        for (Clue c: game.getCurrentGameSnapshot().journal.getClues()) {
                             if (c.getName().equals(clueLabel.getText().toString())) {
                                 currentClue = c;
                                 updateClue();
@@ -271,11 +271,11 @@ public class JournalScreen extends AbstractScreen {
             content.row();
         }
 
-        if (!game.gameSnapshot.journal.getClues().isEmpty()) {
+        if (!game.getCurrentGameSnapshot().journal.getClues().isEmpty()) {
             currentClue =
-                game.gameSnapshot.journal
+                game.getCurrentGameSnapshot().journal
                     .getClues()
-                    .get(game.gameSnapshot.journal.getClues().size() - 1);
+                    .get(game.getCurrentGameSnapshot().journal.getClues().size() - 1);
             updateClue();
         }
 
@@ -343,7 +343,7 @@ public class JournalScreen extends AbstractScreen {
         page.addActor(getJournalPageSubtitle("Click and drag below to scroll", 1));
 
         // Add list of previous conversations to journal
-        List<String> conversations = game.gameSnapshot.journal.getConversations();
+        List<String> conversations = game.getCurrentGameSnapshot().journal.getConversations();
 
         // Loop through each conversation entry and add to table
         Table content = new Table();

--- a/game/core/src/org/teamfarce/mirch/screens/MainMenuScreen.java
+++ b/game/core/src/org/teamfarce/mirch/screens/MainMenuScreen.java
@@ -51,7 +51,7 @@ public class MainMenuScreen extends AbstractScreen {
     public MainMenuScreen(final MIRCH game, Skin uiSkin) {
 
         super(game);
-        this.gameSnapshot = game.gameSnapshot;
+        this.gameSnapshot = game.getCurrentGameSnapshot();
 
         // Initialising new stage
         stage = new Stage(new FitViewport(Gdx.graphics.getWidth(), Gdx.graphics.getHeight()));

--- a/game/core/src/org/teamfarce/mirch/screens/MapScreen.java
+++ b/game/core/src/org/teamfarce/mirch/screens/MapScreen.java
@@ -44,7 +44,7 @@ public class MapScreen extends AbstractScreen {
     /**
      * This stores the room arrow that is drawn when the player stands on a room changing mat
      */
-    private RoomArrow arrow = new RoomArrow(game.player);
+    private RoomArrow arrow = new RoomArrow(game.getCurrentGameSnapshot().player);
     /**
      * This is the sprite batch that is relative to the screens origin
      */
@@ -80,11 +80,11 @@ public class MapScreen extends AbstractScreen {
         this.camera.setToOrtho(false, w, h);
         this.camera.update();
         this.tileRender =
-            new OrthogonalTiledMapRendererWithPeople(game.player.getRoom().getTiledMap(), game);
-        this.tileRender.addPerson(game.player);
-        currentNPCs = game.gameSnapshot.map.getNPCs(game.player.getRoom());
+            new OrthogonalTiledMapRendererWithPeople(game.getCurrentGameSnapshot().player.getRoom().getTiledMap(), game);
+        this.tileRender.addPerson(game.getCurrentGameSnapshot().player);
+        currentNPCs = game.getCurrentGameSnapshot().map.getNPCs(game.getCurrentGameSnapshot().player.getRoom());
         tileRender.addPerson((List<AbstractPerson>) ((List<? extends AbstractPerson>) currentNPCs));
-        this.playerController = new PlayerController(game.player, game, camera);
+        this.playerController = new PlayerController(game.getCurrentGameSnapshot().player, game, camera);
         this.spriteBatch = new SpriteBatch();
 
         Pixmap pixMap =
@@ -95,7 +95,7 @@ public class MapScreen extends AbstractScreen {
 
         BLACK_BACKGROUND = new Sprite(new Texture(pixMap));
 
-        this.statusBar = new StatusBar(game.gameSnapshot, uiSkin);
+        this.statusBar = new StatusBar(game.getCurrentGameSnapshot(), uiSkin);
     }
 
     @Override
@@ -108,17 +108,17 @@ public class MapScreen extends AbstractScreen {
 
     @Override
     public void render(float delta) {
-        game.gameSnapshot.scoreTracker.incrementGameTicks();
+        game.getCurrentGameSnapshot().scoreTracker.incrementGameTicks();
         playerController.update(delta);
-        game.player.update(delta);
+        game.getCurrentGameSnapshot().player.update(delta);
 
         // loop through each suspect character, moving them randomly
         for (Suspect character: currentNPCs) {
             character.update(delta);
         }
 
-        camera.position.x = game.player.getX();
-        camera.position.y = game.player.getY();
+        camera.position.x = game.getCurrentGameSnapshot().player.getX();
+        camera.position.y = game.getCurrentGameSnapshot().player.getY();
         camera.update();
         tileRender.setView(camera);
 
@@ -126,7 +126,7 @@ public class MapScreen extends AbstractScreen {
         tileRender.getBatch().begin();
         arrow.update();
         arrow.draw(tileRender.getBatch());
-        game.player.getRoom().drawClues(delta, getTileRenderer().getBatch());
+        game.getCurrentGameSnapshot().player.getRoom().drawClues(delta, getTileRenderer().getBatch());
 
         tileRender.getBatch().end();
 
@@ -154,7 +154,7 @@ public class MapScreen extends AbstractScreen {
      * This is called when the player decides to move to another room
      */
     public void initialiseRoomTransition() {
-        game.gameSnapshot.setAllUnlocked();
+        game.getCurrentGameSnapshot().setAllUnlocked();
         roomTransition = true;
     }
 
@@ -186,14 +186,14 @@ public class MapScreen extends AbstractScreen {
                 animTimer += delta;
 
                 if (animTimer >= ANIM_TIME) {
-                    game.player.moveRoom();
-                    currentNPCs = game.gameSnapshot.map.getNPCs(game.player.getRoom());
-                    getTileRenderer().setMap(game.player.getRoom().getTiledMap());
+                    game.getCurrentGameSnapshot().player.moveRoom();
+                    currentNPCs = game.getCurrentGameSnapshot().map.getNPCs(game.getCurrentGameSnapshot().player.getRoom());
+                    getTileRenderer().setMap(game.getCurrentGameSnapshot().player.getRoom().getTiledMap());
                     getTileRenderer().clearPeople();
                     getTileRenderer().addPerson(
                         (List<AbstractPerson>) ((List<? extends AbstractPerson>) currentNPCs)
                     );
-                    getTileRenderer().addPerson(game.player);
+                    getTileRenderer().addPerson(game.getCurrentGameSnapshot().player);
                 }
 
                 if (animTimer > ANIM_TIME) {
@@ -208,9 +208,9 @@ public class MapScreen extends AbstractScreen {
             }
         }
 
-        if (game.player.roomChange) {
+        if (game.getCurrentGameSnapshot().player.roomChange) {
             initialiseRoomTransition();
-            game.player.roomChange = false;
+            game.getCurrentGameSnapshot().player.roomChange = false;
         }
     }
 

--- a/game/core/src/org/teamfarce/mirch/screens/MapScreen.java
+++ b/game/core/src/org/teamfarce/mirch/screens/MapScreen.java
@@ -80,11 +80,17 @@ public class MapScreen extends AbstractScreen {
         this.camera.setToOrtho(false, w, h);
         this.camera.update();
         this.tileRender =
-            new OrthogonalTiledMapRendererWithPeople(game.getCurrentGameSnapshot().player.getRoom().getTiledMap(), game);
+            new OrthogonalTiledMapRendererWithPeople(
+                game.getCurrentGameSnapshot().player.getRoom().getTiledMap(),
+                game
+            );
         this.tileRender.addPerson(game.getCurrentGameSnapshot().player);
-        currentNPCs = game.getCurrentGameSnapshot().map.getNPCs(game.getCurrentGameSnapshot().player.getRoom());
+        currentNPCs =
+            game.getCurrentGameSnapshot().map
+                .getNPCs(game.getCurrentGameSnapshot().player.getRoom());
         tileRender.addPerson((List<AbstractPerson>) ((List<? extends AbstractPerson>) currentNPCs));
-        this.playerController = new PlayerController(game.getCurrentGameSnapshot().player, game, camera);
+        this.playerController =
+            new PlayerController(game.getCurrentGameSnapshot().player, game, camera);
         this.spriteBatch = new SpriteBatch();
 
         Pixmap pixMap =
@@ -126,7 +132,9 @@ public class MapScreen extends AbstractScreen {
         tileRender.getBatch().begin();
         arrow.update();
         arrow.draw(tileRender.getBatch());
-        game.getCurrentGameSnapshot().player.getRoom().drawClues(delta, getTileRenderer().getBatch());
+        game.getCurrentGameSnapshot().player
+            .getRoom()
+            .drawClues(delta, getTileRenderer().getBatch());
 
         tileRender.getBatch().end();
 
@@ -187,8 +195,11 @@ public class MapScreen extends AbstractScreen {
 
                 if (animTimer >= ANIM_TIME) {
                     game.getCurrentGameSnapshot().player.moveRoom();
-                    currentNPCs = game.getCurrentGameSnapshot().map.getNPCs(game.getCurrentGameSnapshot().player.getRoom());
-                    getTileRenderer().setMap(game.getCurrentGameSnapshot().player.getRoom().getTiledMap());
+                    currentNPCs =
+                        game.getCurrentGameSnapshot().map
+                            .getNPCs(game.getCurrentGameSnapshot().player.getRoom());
+                    getTileRenderer()
+                        .setMap(game.getCurrentGameSnapshot().player.getRoom().getTiledMap());
                     getTileRenderer().clearPeople();
                     getTileRenderer().addPerson(
                         (List<AbstractPerson>) ((List<? extends AbstractPerson>) currentNPCs)

--- a/game/core/src/org/teamfarce/mirch/screens/NarratorScreen.java
+++ b/game/core/src/org/teamfarce/mirch/screens/NarratorScreen.java
@@ -67,7 +67,7 @@ public class NarratorScreen extends AbstractScreen {
 
         String introSpeech =
             "You have been invited to a lock-in costume party with some of the richest people around. There has been a murder, one of the guests has killed "
-                + game.gameSnapshot.victim.getName() + "\n\n"
+                + game.getCurrentGameSnapshot().victim.getName() + "\n\n"
                 + "The murderer instantly regretted their decision and has tried their hardest to cover up their tracks. All the clues have been hidden around the Ron Cooke Hub by the murderer so that they can avoid being discovered.\n\n"
                 + "NOT SO FAST! You're not the only detective that got called to the scene, there will be other detectives trying to solve the case at the same time.\n\n"
                 + "You must go around each room trying to find the clues that have been hidden. You must also question the guests to see if they know anything about the murder! Try to solve the case before any other detective!";
@@ -79,7 +79,7 @@ public class NarratorScreen extends AbstractScreen {
             new Runnable() {
                 @Override
                 public void run() {
-                    game.gameSnapshot.setState(GameState.map);
+                    game.getCurrentGameSnapshot().setState(GameState.map);
                 }
             }
         );

--- a/game/tests/src/org/teamfarce/mirch/GUIControllerTest.java
+++ b/game/tests/src/org/teamfarce/mirch/GUIControllerTest.java
@@ -62,7 +62,7 @@ public class GUIControllerTest extends GameTest {
     @Before
     public void init_tests() {
         game = new MIRCH();
-        game.gameSnapshot = new GameSnapshot(null, null, null, null, null);
+        game.setGameSnapshot(new GameSnapshot(null, null, null, null, null));
     }
 
     @Test
@@ -88,7 +88,7 @@ public class GUIControllerTest extends GameTest {
         assertSame(game.getScreen(), null);
 
         // Set MapScreen as active
-        game.gameSnapshot.setState(GameState.map);
+        game.getCurrentGameSnapshot().setState(GameState.map);
         guiController.update();
 
         // Check MapScreen is active
@@ -101,7 +101,7 @@ public class GUIControllerTest extends GameTest {
     public void screenCanBeChanged() {
 
         // Init GUIController with active MapScreen
-        game.gameSnapshot.setState(GameState.map);
+        game.getCurrentGameSnapshot().setState(GameState.map);
         GUIController guiController = new GUIController(game);
         guiController.journalScreen = screen1;
         guiController.mapScreen = screen2;
@@ -113,7 +113,7 @@ public class GUIControllerTest extends GameTest {
         assertNotSame(game.getScreen(), guiController.journalScreen);
 
         // Switch to JournalScreen
-        game.gameSnapshot.setState(GameState.journalClues);
+        game.getCurrentGameSnapshot().setState(GameState.journalClues);
         guiController.update();
 
         // Check JournalScreen is active

--- a/game/tests/src/org/teamfarce/mirch/JournalTest.java
+++ b/game/tests/src/org/teamfarce/mirch/JournalTest.java
@@ -15,7 +15,7 @@ public class JournalTest extends GameTest {
     @Test
     public void addClue() {
         MIRCH game = new MIRCH();
-        game.gameSnapshot = new GameSnapshot(game, null, null, new ArrayList<Suspect>(), null);
+        game.setGameSnapshot(new GameSnapshot(game, null, null, new ArrayList<Suspect>(), null));
 
         Journal journal = new Journal(game);
         Clue clue = new Clue("Clue name", "Description", "clueSheet.png", 0, 0, false);
@@ -28,7 +28,7 @@ public class JournalTest extends GameTest {
     @Test
     public void getClues() {
         MIRCH game = new MIRCH();
-        game.gameSnapshot = new GameSnapshot(game, null, null, new ArrayList<Suspect>(), null);
+        game.setGameSnapshot(new GameSnapshot(game, null, null, new ArrayList<Suspect>(), null));
 
         Journal journal = new Journal(game);
         ArrayList<Clue> cluesList = new ArrayList<>();

--- a/game/tests/src/org/teamfarce/mirch/NarratorScreenTest.java
+++ b/game/tests/src/org/teamfarce/mirch/NarratorScreenTest.java
@@ -16,8 +16,8 @@ public class NarratorScreenTest extends GameTest {
     public void init_tests() {
         Skin skin = new Skin();
         game = new MIRCH();
-        game.gameSnapshot = new GameSnapshot(null, null, null, null, null);
-        game.gameSnapshot.victim =
+        game.setGameSnapshot(new GameSnapshot(null, null, null, null, null));
+        game.getCurrentGameSnapshot().victim =
             new Suspect(game, "Test", "test", "Colin.png", new Vector2Int(0, 0), null);
         screen = new NarratorScreen(game, skin);
     }

--- a/game/tests/src/org/teamfarce/mirch/SuspectTest.java
+++ b/game/tests/src/org/teamfarce/mirch/SuspectTest.java
@@ -21,15 +21,14 @@ public class SuspectTest {
         Vector2Int position = new Vector2Int(0, 1);
 
         MIRCH game = new MIRCH();
-        game.gameSnapshot =
-            new GameSnapshot(
-                game,
-                new Map(game),
-                new ArrayList<Room>(),
-                new ArrayList<Suspect>(),
-                null
-            );
-        game.gameSnapshot.victim =
+        game.setGameSnapshot(new GameSnapshot(
+            game,
+            new Map(game),
+            new ArrayList<Room>(),
+            new ArrayList<Suspect>(),
+            null
+        ));
+        game.getCurrentGameSnapshot().victim =
             new Suspect(game, "Test", "test", "Colin.png", new Vector2Int(0, 0), null);
         game.guiController = new GUIController(game);
         game.guiController.narratorScreen = new NarratorScreen(game, new Skin());

--- a/game/tests/src/org/teamfarce/mirch/SuspectTest.java
+++ b/game/tests/src/org/teamfarce/mirch/SuspectTest.java
@@ -21,13 +21,15 @@ public class SuspectTest {
         Vector2Int position = new Vector2Int(0, 1);
 
         MIRCH game = new MIRCH();
-        game.setGameSnapshot(new GameSnapshot(
-            game,
-            new Map(game),
-            new ArrayList<Room>(),
-            new ArrayList<Suspect>(),
-            null
-        ));
+        game.setGameSnapshot(
+            new GameSnapshot(
+                game,
+                new Map(game),
+                new ArrayList<Room>(),
+                new ArrayList<Suspect>(),
+                null
+            )
+        );
         game.getCurrentGameSnapshot().victim =
             new Suspect(game, "Test", "test", "Colin.png", new Vector2Int(0, 0), null);
         game.guiController = new GUIController(game);


### PR DESCRIPTION
Refactored to allow for multiple players. Player, Rooms (this is odd as
they had two Room lists, so I’ve given each a distinct name) and
Characters have been moved into gameSnapshot. An array of gameSnapshots
now exists in MIRCH, with two new functions - one to access the current
game snapshot (getCurrentGameSnapshot()) and one to move to the next
game snapshot in the list. Two game snapshots are created, although i
can not guarantee that these are identical (we can’t copy across the
objects due to Java’s lack of functional deep copy) so this has to be
managed in the game generation class. Currently only the 1st game
snapshot is played - the second is fully populated but is never used, its up to peter to sort
out transitions from one to the other.